### PR TITLE
Make multibook configuration backwards compatible

### DIFF
--- a/lichess-bot.py
+++ b/lichess-bot.py
@@ -367,6 +367,9 @@ def get_book_move(board, config):
         else:
             return None
 
+    if isinstance(books, str):
+        books = [books]
+
     for book in books:
         with chess.polyglot.open_reader(book) as reader:
             try:


### PR DESCRIPTION
After a PR, lichess-bot expects each polyglot book to come in a list.
Older configuration files will only have a single book name in a
non-list format, causing the letters of that book name to be iterated
over. This change makes sure that the single book comes in list form.